### PR TITLE
 Add .travis.yml to run tests and submit coverage to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: java
+jdk:
+  - openjdk8
+  - oraclejdk9
+
+script:
+  - mvn clean test jacoco:report
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The codecov.io report is (for now, since Travis is not enabled for this repository) at https://codecov.io/gh/jdanekrh/pooled-jms/tree/fc682b5da9c17351027f27f9a7830cccad359806