### PR TITLE
NotForMerging: failing testSendRecvRecvSendRecvWith{AMQP,Core}

### DIFF
--- a/pooled-jms-interop-tests/pooled-jms-artemis-tests/pom.xml
+++ b/pooled-jms-interop-tests/pooled-jms-artemis-tests/pom.xml
@@ -15,7 +15,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.messaginghub</groupId>
@@ -39,10 +40,28 @@
     <!-- Adding the JMS 1.1 API jar for these tests explicitly, first,
          since its whats implemented by ActiveMQ, and also helps to
          verify the pool works when both APIs are on the classpath -->
+    <!--<dependency>-->
+    <!--<groupId>org.apache.geronimo.specs</groupId>-->
+    <!--<artifactId>geronimo-jms_1.1_spec</artifactId>-->
+    <!--</dependency>-->
+    <!--let's get 2.0, Artemis implements that, and to have autocloseable resources-->
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jms_1.1_spec</artifactId>
+      <artifactId>geronimo-jms_2.0_spec</artifactId>
     </dependency>
+    <!--so I can try more clients-->
+    <dependency>
+      <groupId>org.apache.qpid</groupId>
+      <artifactId>qpid-jms-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-amqp-protocol</artifactId>
+      <version>${artemis-version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.geronimo.components</groupId>
       <artifactId>geronimo-transaction</artifactId>

--- a/pooled-jms-interop-tests/pooled-jms-artemis-tests/src/test/java/org/messaginghub/pooled/jms/ArtemisJmsPoolTestSupport.java
+++ b/pooled-jms-interop-tests/pooled-jms-artemis-tests/src/test/java/org/messaginghub/pooled/jms/ArtemisJmsPoolTestSupport.java
@@ -16,25 +16,33 @@
  */
 package org.messaginghub.pooled.jms;
 
+import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedJMSResource;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ArtemisJmsPoolTestSupport {
 
     @Rule public TestName name = new TestName();
-    @Rule public EmbeddedJMSResource server = new EmbeddedJMSResource(false);
+    @ClassRule public static EmbeddedJMSResource server = new EmbeddedJMSResource(true);
 
     protected static final Logger LOG = LoggerFactory.getLogger(ArtemisJmsPoolTestSupport.class);
 
     protected ActiveMQConnectionFactory artemisJmsConnectionFactory;
     protected JmsPoolConnectionFactory cf;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Configuration configuration = server.getJmsServer().getActiveMQServer().getConfiguration();
+        configuration.addAcceptorConfiguration("amqp", "tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpMinCredits=300;multicastPrefix=topic://");
+    }
 
     @Before
     public void setUp() throws Exception {

--- a/pooled-jms-interop-tests/pooled-jms-artemis-tests/src/test/java/org/messaginghub/pooled/jms/ArtemisJmsPoolTestSupport.java
+++ b/pooled-jms-interop-tests/pooled-jms-artemis-tests/src/test/java/org/messaginghub/pooled/jms/ArtemisJmsPoolTestSupport.java
@@ -31,18 +31,12 @@ import org.slf4j.LoggerFactory;
 public class ArtemisJmsPoolTestSupport {
 
     @Rule public TestName name = new TestName();
-    @ClassRule public static EmbeddedJMSResource server = new EmbeddedJMSResource(true);
+    @Rule public EmbeddedJMSResource server = new EmbeddedJMSResource(true);
 
     protected static final Logger LOG = LoggerFactory.getLogger(ArtemisJmsPoolTestSupport.class);
 
     protected ActiveMQConnectionFactory artemisJmsConnectionFactory;
     protected JmsPoolConnectionFactory cf;
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-        Configuration configuration = server.getJmsServer().getActiveMQServer().getConfiguration();
-        configuration.addAcceptorConfiguration("amqp", "tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpMinCredits=300;multicastPrefix=topic://");
-    }
 
     @Before
     public void setUp() throws Exception {

--- a/pooled-jms-interop-tests/pooled-jms-artemis-tests/src/test/java/org/messaginghub/pooled/jms/SendAndReceiveTests.java
+++ b/pooled-jms-interop-tests/pooled-jms-artemis-tests/src/test/java/org/messaginghub/pooled/jms/SendAndReceiveTests.java
@@ -1,0 +1,108 @@
+package org.messaginghub.pooled.jms;
+
+import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SendAndReceiveTests extends ArtemisJmsPoolTestSupport {
+
+    @Test
+    public void testSendRecvRecvSendRecvWithCore() throws Exception {
+        final ConnectionFactory connectionFactory = getCoreConnectionFactory();
+        doTestSendRecvRecvSendRecv(connectionFactory);
+    }
+
+    @Test
+    public void testSendRecvRecvSendRecvWithAMQP() throws Exception {
+        final ConnectionFactory connectionFactory = getAMQPConnectionFactory();
+        doTestSendRecvRecvSendRecv(connectionFactory);
+    }
+
+    void doTestSendRecvRecvSendRecv(final ConnectionFactory connectionFactory) throws Exception {
+        final AtomicInteger counter = new AtomicInteger(0);
+        final Queue queue = new ActiveMQQueue("MyLiQueueRe");
+
+        // send
+        SendAndReceiveTests.sendMessage(connectionFactory, counter, queue);
+
+        // receive something
+        try (
+                Connection connection = connectionFactory.createConnection();
+                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                MessageConsumer consumer = session.createConsumer(queue);
+        ) {
+            connection.start();
+            final TextMessage message = (TextMessage) consumer.receive(2000);
+            Assert.assertNotNull(message);
+        }
+        // receive nothing
+        try (
+                Connection connection = connectionFactory.createConnection();
+                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                MessageConsumer consumer = session.createConsumer(queue);
+        ) {
+            connection.start();
+            final TextMessage message = (TextMessage) consumer.receive(2000);
+            Assert.assertNull(message);
+        }
+
+        // send
+        SendAndReceiveTests.sendMessage(connectionFactory, counter, queue);
+
+        // tried this just in case the cause is similar to https://issues.jboss.org/browse/ENTMQBR-72
+//        Thread.sleep(120000);
+
+        // receive something
+        try (
+                Connection connection = connectionFactory.createConnection();
+                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                MessageConsumer consumer = session.createConsumer(queue);
+        ) {
+            connection.start();
+            final TextMessage message = (TextMessage) consumer.receive(2000);
+            Assert.assertNotNull(message);
+            System.out.println(message.getText());
+        }
+    }
+
+    static void sendMessage(ConnectionFactory connectionFactory, AtomicInteger counter, Queue queue) throws
+            JMSException {
+        try (
+                Connection connection = connectionFactory.createConnection();
+                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                MessageProducer producer = session.createProducer(queue);
+        ) {
+            connection.start();
+            final TextMessage message = session.createTextMessage();
+            message.setText(String.valueOf(counter.getAndIncrement()));
+            producer.send(message);
+        }
+    }
+
+    ConnectionFactory getCoreConnectionFactory() {
+        return cf;
+    }
+
+    ConnectionFactory getAMQPConnectionFactory() {
+        JmsConnectionFactory connectionFactory = new JmsConnectionFactory();
+        connectionFactory.setRemoteURI("failover:(amqp://localhost:61616)");
+        connectionFactory.setUsername("admin");
+        connectionFactory.setPassword("admin");
+
+        JmsPoolConnectionFactory pool = new org.messaginghub.pooled.jms.JmsPoolConnectionFactory();
+        pool.setConnectionFactory(connectionFactory);
+        pool.setUseAnonymousProducers(false);
+        return pool;
+    }
+}


### PR DESCRIPTION
This is the test that is failing for me, even though I believe it should pass. If you change Artemis version in pom.xml to `<artemis.version>2.4.0</artemis.version>`, then the AMQP variant passes and Core variant fails. If you leave broker at 2.5.0 (or set the upcoming 2.6.0), then both tests fail. The line where assertion error is thrown if the test fails is marked by comment on the PR.

Can you please have a look, what is happening here?