### PR TITLE
ensure temp dests are cleaned up on close even when there is an open …

### DIFF
--- a/pooled-jms/src/main/java/org/messaginghub/pooled/jms/JmsPoolConnection.java
+++ b/pooled-jms/src/main/java/org/messaginghub/pooled/jms/JmsPoolConnection.java
@@ -77,8 +77,8 @@ public class JmsPoolConnection implements TopicConnection, QueueConnection, JmsP
     @Override
     public void close() throws JMSException {
         if (closed.compareAndSet(false, true)) {
-            this.cleanupConnectionTemporaryDestinations();
             this.cleanupAllLoanedSessions();
+            this.cleanupConnectionTemporaryDestinations();
             if (this.connection != null) {
                 this.connection.decrementReferenceCount();
                 this.connection = null;


### PR DESCRIPTION
…consumer, sessions should be cleaned first

same issue as: https://issues.apache.org/jira/browse/AMQ-7233