### PR TITLE
use JDK 17 for CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 16 ]
+        java: [ 11, 17 ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Update from from using JDK 11+16 to 11+17 for the CI job