### PR TITLE
Fix session pooling under load

### DIFF
--- a/pooled-jms/src/main/java/org/messaginghub/pooled/jms/pool/PooledConnection.java
+++ b/pooled-jms/src/main/java/org/messaginghub/pooled/jms/pool/PooledConnection.java
@@ -293,6 +293,7 @@ public class PooledConnection implements ExceptionListener {
 
     public void setMaxSessionsPerConnection(int maActiveSessionsPerConnection) {
         this.sessionPool.setMaxTotalPerKey(maActiveSessionsPerConnection);
+        this.sessionPool.setMaxIdlePerKey(maActiveSessionsPerConnection);
     }
 
     public boolean isUseAnonymousProducers() {


### PR DESCRIPTION
When pooled sessions are closed, only up to `DEFAULT_MAX_IDLE_PER_KEY` are kept. Above that number they are destroyed.

Under load, this causes a great number of sessions being created and contention on the `ActiveMQConnection`.